### PR TITLE
[WEB-4029] move package from npm to github packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/Pitchero/next-routes.git"
   },
+  "publishConfig": {
+    "registry":"https://npm.pkg.github.com/pitchero"
+  },
   "main": "dist",
   "typings": "typings/next-routes.d.ts",
   "files": [


### PR DESCRIPTION
Changes as per instructions found here:
https://medium.com/@emanuele.pecorari/move-from-npmjs-to-github-package-registry-in-5-steps-ac09ad17f25c